### PR TITLE
fix: php 7 isset() cannot be triggered in activerecord lib

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -703,6 +703,12 @@ class BelongsTo extends AbstractRelationship
 			$this->primary_key = is_array($this->options['primary_key']) ? $this->options['primary_key'] : array($this->options['primary_key']);
 	}
 
+	public function __isset($name)
+	{
+		$attribute = $this->{$name};
+		return isset($attribute);
+	}
+
 	public function __get($name)
 	{
 		if($name === 'primary_key' && !isset($this->primary_key)) {


### PR DESCRIPTION
修正 php 7 isset 不會觸發 activerecord __get